### PR TITLE
Migrate tests to JUnit5

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/figlet_buildstep/FigletStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/figlet_buildstep/FigletStepTest.java
@@ -1,20 +1,26 @@
 package org.jenkinsci.plugins.figlet_buildstep;
 
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 /**
  * Created by acearl on 9/15/2015.
  */
-public class FigletStepTest {
+@WithJenkins
+class FigletStepTest {
 
-    @Rule
-    public JenkinsRule j = new JenkinsRule();
+    private JenkinsRule j;
+
+    @BeforeEach
+    void setUp(JenkinsRule rule) {
+        j = rule;
+    }
 
     @Test
-    public void configRoundTrip() throws Exception {
+    void configRoundTrip() throws Exception {
         FigletStep step1 = new FigletStep("Boo");
         FigletStep step2 = new StepConfigTester(j).configRoundTrip(step1);
         j.assertEqualDataBoundBeans(step1, step2);


### PR DESCRIPTION
This PR aims to migrate all tests to JUnit5. Changes include:

* Migrate annotations and imports
* Migrate assertions
* Remove public visibility for test classes and methods
* Minor clean up

I am well aware that this is a quite large changeset however I hope that there is still interest in this PR and it will be reviewed.
If there are any questions, please do not hesitate to ping me.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub 
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
